### PR TITLE
Fix minimap sizing issue and make sure flatmap-viewer 2.2.9 is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/flatmapvuer",
-  "version": "0.3.13-beta-2",
+  "version": "0.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13250,9 +13250,9 @@
           "optional": true
         },
         "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
           "dev": true,
           "optional": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1331,9 +1331,9 @@
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "@mapbox/tiny-sdf": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-      "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.1",
@@ -2972,9 +2972,9 @@
       }
     },
     "bezier-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.0.tgz",
-      "integrity": "sha512-oc8fkHqG0R+dQuNiXVbPMB0cc8iDqkLAjbA2gq26QmV8tZqW9GGI7iNEX1ioRWlZperQS7v5BX03+9FLVWZbSw=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.3.tgz",
+      "integrity": "sha512-VPFvkyO98oCJ1Tsi+bFBrKEWLdefAj4DJVaWp3xTEsdCbunC7Pt/nTeIgu/UdskBNcmHv8TOfsgdMZb1GsICmg=="
     },
     "bfj": {
       "version": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/flatmapvuer",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "main": "./dist/flatmapvuer.common.js",
   "files": [
     "dist/*",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@abi-software/flatmap-viewer": "^2.2.9",
+    "@abi-software/flatmap-viewer": "2.2.9",
     "@abi-software/svg-sprite": "^0.1.14",
     "core-js": "^3.3.2",
     "css-element-queries": "^1.2.2",

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1349,17 +1349,15 @@ export default {
       width: 180px !important; 
     }
   }
-  transition: all 1s ease;
-  &.enlarge {
-    @media (max-width: 1250px) {
-      height: 125px !important; 
-      width: 180px !important;
-    }
-    @media (min-width: 1251px) {
+  @media (min-width: 1251px) {
+    height: 190px !important;
+    width: 300px !important;
+    >>> .maplibregl-canvas .mapboxgl-canvas {
       height: 190px !important;
-      width: 300px !important;
+      width: 300px !important; 
     }
   }
+  transition: all 1s ease;
   &.shrink {
     transform: scale(0.5); 
     transform: scale(0.5);

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1354,7 +1354,7 @@ export default {
     width: 300px !important;
     >>> .maplibregl-canvas .mapboxgl-canvas {
       height: 190px !important;
-      width: 300px !important; 
+      width: 300px !important;
     }
   }
   transition: all 1s ease;

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1342,11 +1342,11 @@ export default {
 ::v-deep .maplibregl-ctrl-minimap {
   transform-origin: top right;
   @media (max-width: 1250px) {
-    height: 125px !important; // important is needed here as we are over-riding the style set by the flatmap
+    height: 125px !important;// important is needed here as we are over-riding the style set by the flatmap
     width: 180px !important;
     >>> .maplibregl-canvas .mapboxgl-canvas {
       height: 125px !important;
-      width: 180px !important; 
+      width: 180px !important;
     }
   }
   @media (min-width: 1251px) {

--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -161,7 +161,6 @@ export default {
     },
     FlatmapReady: function(component) {
       this.$emit("ready", component);
-      this.addCloseButtonToMinimap();
     },
     getCoordinatesOfLastClick: function() {
       const flatmap = this.$refs[this.activeSpecies];
@@ -507,5 +506,4 @@ export default {
 }
 
 </style>
-
 


### PR DESCRIPTION
Bug fixes on minimap, expanding minimap from shrink creates some padding at the bottom previously.

The newer flatmap-viewer contains a bug that cause weird shapes pop up everywhere so make sure it stays at 2.2.9.