### PR TITLE
Add a property to disable UI elements 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,29 +9,48 @@
     >
       <div class="options-container">
         <el-row :gutter="20">
-          <el-button @click="helpMode = !helpMode" size="small"
-            >Help Mode</el-button
-          >
-          <el-button @click="saveSettings()" size="small"
-            >Save Settings</el-button
-          >
-          <el-button
-            :disabled="mapSettings.length === 0"
-            @click="restoreSettings()"
-            size="small"
-            >Restore Settings</el-button
-          >
-          <el-autocomplete
-            class="search-box"
-            placeholder="Search"
-            v-model="searchText"
-            :fetch-suggestions="fetchSuggestions"
-            @keyup.enter="search"
-            @select="search"
-            popper-class="autocomplete-popper"
-            :teleported="false"
-          >
-          </el-autocomplete>
+          <el-col :span="8">
+            <el-button @click="helpMode = !helpMode" size="small"
+              >Help Mode</el-button
+            >
+          </el-col>
+          <el-col :span="8">
+            <el-button @click="saveSettings()" size="small"
+              >Save Settings</el-button
+            >
+          </el-col>
+          <el-col :span="8">
+            <el-button
+              :disabled="mapSettings.length === 0"
+              @click="restoreSettings()"
+              size="small"
+              >Restore Settings</el-button
+            >
+          </el-col>
+        </el-row>
+        <el-row>
+          <el-col>
+            <el-switch
+              v-model="disableUI"
+              active-text="Disable UI"
+            >
+            </el-switch>
+          </el-col>
+        </el-row>
+        <el-row>
+          <el-col>
+            <el-autocomplete
+              class="search-box"
+              placeholder="Search"
+              v-model="searchText"
+              :fetch-suggestions="fetchSuggestions"
+              @keyup.enter="search"
+              @select="search"
+              popper-class="autocomplete-popper"
+              :teleported="false"
+            >
+            </el-autocomplete>
+          </el-col>
         </el-row>
       </div>
       <template #reference>
@@ -57,6 +76,7 @@
       :displayMinimap="true"
       :enableOpenMapUI="true"
       :flatmapAPI="flatmapAPI"
+      :disableUI="disableUI"
     />
   </div>
 </template>
@@ -150,6 +170,7 @@ export default {
       searchable: true,
       pathControls: true,
       layerControl: true,
+      disableUI: false,
       minZoom: 4,
       availableSpecies: {
         'Human Female': {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,6 +9,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     AnnotationTool: typeof import('./components/AnnotationTool.vue')['default']
     DynamicLegends: typeof import('./components/legends/DynamicLegends.vue')['default']
+    ElAutocomplete: typeof import('element-plus/es')['ElAutocomplete']
     ElButton: typeof import('element-plus/es')['ElButton']
     ElCheckbox: typeof import('element-plus/es')['ElCheckbox']
     ElCheckboxGroup: typeof import('element-plus/es')['ElCheckboxGroup']
@@ -29,6 +30,7 @@ declare module 'vue' {
     ElRadioGroup: typeof import('element-plus/es')['ElRadioGroup']
     ElRow: typeof import('element-plus/es')['ElRow']
     ElSelect: typeof import('element-plus/es')['ElSelect']
+    ElSwitch: typeof import('element-plus/es')['ElSwitch']
     ElTree: typeof import('element-plus/es')['ElTree']
     ExternalResourceCard: typeof import('./components/ExternalResourceCard.vue')['default']
     FlatmapVuer: typeof import('./components/FlatmapVuer.vue')['default']

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -11,7 +11,7 @@
       style="height: 100%; width: 100%; position: relative; overflow-y: none"
     >
       <div style="height: 100%; width: 100%" ref="display"></div>
-      <div class="beta-popovers">
+      <div class="beta-popovers" v-if="!disableUI">
         <div>
           <el-popover
             placement="right"
@@ -136,7 +136,7 @@
         <el-icon-arrow-down />
       </el-icon>
 
-      <div class="bottom-right-control">
+      <div class="bottom-right-control" v-if="!disableUI">
         <el-popover
           content="Zoom in"
           placement="left"
@@ -208,6 +208,7 @@
         popper-class="flatmap-popper"
         :visible="hoverVisibilities[4].value"
         ref="checkBoxPopover"
+        v-if="!disableUI"
       >
         <template #reference>
           <div
@@ -279,7 +280,7 @@
                 ref="centrelinesSelection"
                 key="centrelinesSelection"
               />
-              <!--             
+              <!--
                 <selections-group
                   v-if="isFC && sckanDisplay && sckanDisplay.length > 0"
                   title="SCKAN"
@@ -429,6 +430,7 @@
       <div
         class="settings-group"
         :class="{ open: drawerOpen, close: !drawerOpen }"
+        v-if="!disableUI"
       >
         <el-row>
           <el-popover
@@ -975,6 +977,11 @@ export default {
     },
     displayTooltip: function (feature) {
       this.tooltipDisplay = true
+      if (!this.disableUI) {
+        this.displayPopup(feature)
+      }
+    },
+    displayPopup: function (feature) {
       this.mapImp.showPopup(
         this.mapImp.modelFeatureIds(feature)[0],
         this.$refs.tooltip.$el,
@@ -1337,6 +1344,13 @@ export default {
       type: String,
       default: 'https://api.sparc.science/',
     },
+    /**
+     * Flag to disable UIs on Map
+     */
+     disableUI: {
+      type: Boolean,
+      default: false,
+    }
   },
   provide() {
     return {
@@ -1424,6 +1438,14 @@ export default {
       immediate: true,
       deep: true,
     },
+    disableUI: function (isUIDisabled) {
+      if (isUIDisabled) {
+        this.closeTooltip()
+        // TODO:
+        // to reset the map
+        // to reset the props of disabled components
+      }
+    }
   },
   mounted: function () {
     this.openMapRef = shallowRef(this.$refs.openMapRef)

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -11,7 +11,7 @@
       style="height: 100%; width: 100%; position: relative; overflow-y: none"
     >
       <div style="height: 100%; width: 100%" ref="display"></div>
-      <div class="beta-popovers" v-if="!disableUI">
+      <div class="beta-popovers" v-show="!disableUI">
         <div>
           <el-popover
             placement="right"
@@ -136,7 +136,7 @@
         <el-icon-arrow-down />
       </el-icon>
 
-      <div class="bottom-right-control" v-if="!disableUI">
+      <div class="bottom-right-control" v-show="!disableUI">
         <el-popover
           content="Zoom in"
           placement="left"
@@ -208,12 +208,12 @@
         popper-class="flatmap-popper"
         :visible="hoverVisibilities[4].value"
         ref="checkBoxPopover"
-        v-if="!disableUI"
       >
         <template #reference>
           <div
             class="pathway-location"
             :class="{ open: drawerOpen, close: !drawerOpen }"
+            v-show="!disableUI"
           >
             <div
               class="pathway-container"
@@ -430,7 +430,7 @@
       <div
         class="settings-group"
         :class="{ open: drawerOpen, close: !drawerOpen }"
-        v-if="!disableUI"
+        v-show="!disableUI"
       >
         <el-row>
           <el-popover
@@ -1441,9 +1441,6 @@ export default {
     disableUI: function (isUIDisabled) {
       if (isUIDisabled) {
         this.closeTooltip()
-        // TODO:
-        // to reset the map
-        // to reset the props of disabled components
       }
     }
   },

--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="multi-container" ref="multiContainer">
-    <div style="position: absolute; z-index: 10">
+    <div style="position: absolute; z-index: 10" v-if="!disableUI">
       <div class="species-display-text">Species</div>
       <el-popover
         content="Select a species"
@@ -51,6 +51,7 @@
       :ref="key"
       :enableOpenMapUI="enableOpenMapUI"
       :openMapOptions="openMapOptions"
+      :disableUI="disableUI"
       @view-latest-map="viewLatestMap"
       @resource-selected="FlatmapSelected"
       @ready="FlatmapReady"
@@ -497,6 +498,13 @@ export default {
       type: String,
       default: 'https://api.sparc.science/',
     },
+    /**
+     * Flag to disable UIs on Map
+     */
+    disableUI: {
+      type: Boolean,
+      default: false,
+    }
   },
   data: function () {
     return {


### PR DESCRIPTION
An option, disable UI, is added to hide UI elements on FlatmapVuer and MultiflatmapVuer. The default option is enable UI and user can switch it on and off in options popup.
The layout of the elements in options popup is updated.