### PR TITLE
Fix popup showing on switching viewingMode

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -377,6 +377,7 @@
             <el-select
               :teleported="false"
               v-model="viewingMode"
+              @change="changeViewingMode"
               placeholder="Select"
               class="select-box"
               popper-class="flatmap_dropdown"
@@ -1026,6 +1027,16 @@ export default {
           this.$emit('pan-zoom-callback', data)
         }
       }
+    },
+    /**
+     * @vuese
+     * Function triggered by viewing mode change.
+     * (e.g., from 'Exploration' to 'Annotation')
+     * All tooltips and popups currently showing on map will be closed
+     * when this function is triggered.
+     */
+     changeViewingMode: function () {
+      this.closeTooltip()
     },
     /**
      * @vuese


### PR DESCRIPTION
This fix is for the popup showing after `viewingMode` change (e.g., from "Exploration" to "Annotation"). 

### How to replicate the issue
**No data issue**
1. Click on a pathway to show a popup (default is on "Exploration" mode).
2. Click **Change settings** button and change **Viewing Mode** from "Exploration" to "Annotation".
3. The existing popup will change to an annotation popup but without data.

**Wrong data issue**
1. Switch the viewing mode to "Annotation".
2. Click a pathway to show a popup. Take note of the pathway (**pathway A**) and its feature ID.
3. Close the popup.
4. Click a different pathway to show a different popup. Take note of the pathway (**pathway B**) and its feature ID.
5. Switch the viewing mode to "Exploration" without closing the popup.
6. The popup's data (feature ID) is from the previous pathway (**pathway A**).

The fix is to close the popup when the viewing mode is changed.