### PR TITLE
Fix api docs demo for pinia

### DIFF
--- a/docs/demo-flatmapvuer.md
+++ b/docs/demo-flatmapvuer.md
@@ -13,8 +13,14 @@
 </div>
 
 <script setup>
+import { getCurrentInstance } from 'vue'
+import { createPinia } from 'pinia'
 import { defineClientComponent } from 'vitepress'
 import './demo-styles.css'
+
+const app = getCurrentInstance()
+const pinia = createPinia()
+app.appContext.app.use(pinia)
 
 const FlatmapVuer = defineClientComponent(() => {
   return import('../src/components/FlatmapVuer.vue')

--- a/docs/demo-multiflatmapvuer.md
+++ b/docs/demo-multiflatmapvuer.md
@@ -21,8 +21,14 @@
 </div>
 
 <script setup>
+import { getCurrentInstance } from 'vue'
+import { createPinia } from 'pinia'
 import { defineClientComponent } from 'vitepress'
 import './demo-styles.css'
+
+const app = getCurrentInstance()
+const pinia = createPinia()
+app.appContext.app.use(pinia)
 
 const MultiFlatmapVuer = defineClientComponent(() => {
   return import('../src/components/MultiFlatmapVuer.vue')


### PR DESCRIPTION
The demo pages on API Docs couldn't load because of the missing `pinia` after adding `pinia` to the main app (#143).

- https://abi-software.github.io/flatmapvuer/demo-flatmapvuer.html
- https://abi-software.github.io/flatmapvuer/demo-multiflatmapvuer.html

This PR is to fix that issue.