### PR TITLE
Fix tooltip arrow on top position

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2024,19 +2024,20 @@ export default {
   }
   &.maplibregl-popup-anchor-top {
     .maplibregl-popup-content {
-      margin-top: 18px;
+      margin-top: 12px;
       &::after,
       &::before {
-        top: calc(-100% - 4px);
+        top: auto;
+        bottom: 100%;
         border-width: 12px;
       }
       /* this border color controlls the color of the triangle (what looks like the fill of the triangle) */
       &::after {
-        margin-top: 1px;
         border-color: transparent transparent rgb(255, 255, 255) transparent;
       }
       &::before {
         margin: 0 auto;
+        margin-bottom: 1px;
         border-color: transparent transparent $app-primary-color transparent;
       }
     }


### PR DESCRIPTION
### Tooltip arrow bug on top position:
![image](https://github.com/ABI-Software/flatmapvuer/assets/161257464/8413bb1f-aa27-4cfd-ae25-543cf88822b1)

This happens when the content in the tooltip is more than one line.

### Fixed:
![image](https://github.com/ABI-Software/flatmapvuer/assets/161257464/c6ba67f1-f6f1-45eb-8b96-bdece5963dae)
