### PR TITLE
Fix popup close error

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1078,13 +1078,13 @@ export default {
      */
     popUpCssHacks: function () {
       // Below is a hack to remove flatmap tooltips while popup is open
-      let ftooltip = document.querySelector('.flatmap-tooltip-popup')
+      const ftooltip = document.querySelector('.flatmap-tooltip-popup')
+      const popupCloseButton = document.querySelector('.maplibregl-popup-close-button')
       if (ftooltip) ftooltip.style.display = 'none'
-      document.querySelector('.maplibregl-popup-close-button').style.display =
-        'block'
+      popupCloseButton.style.display = 'block'
       this.$refs.tooltip.$el.style.display = 'flex'
-      document.querySelector('.maplibregl-popup-close-button').onclick = () => {
-        document.querySelector('.flatmap-tooltip-popup').style.display = 'block'
+      popupCloseButton.onclick = () => {
+        if (ftooltip) ftooltip.style.display = 'block'
       }
     },
     /**


### PR DESCRIPTION
Sometimes, an error is shown in the browser's console after closing the popup. It is because of the tooltip, demonstrated before the popup was opened, but because of the user's mouse move, it was removed from the DOM. 

This fix adds conditional checking for the tooltip DOM element.
