### PR TITLE
Supports the old help mode without help dialog.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -69,6 +69,7 @@
       @ready="FlatmapReady"
       :initial="initial"
       :helpMode="helpMode"
+      :helpModeDialog="useHelpModeDialog"
       :helpModeActiveItem="helpModeActiveItem"
       @help-mode-last-item="onHelpModeLastItem"
       @shown-tooltip="onTooltipShown"
@@ -83,7 +84,7 @@
     />
 
     <HelpModeDialog
-      v-if="helpMode"
+      v-if="helpMode && useHelpModeDialog"
       ref="multiflatmapHelp"
       :multiflatmapRef="multiflatmapRef"
       :lastItem="helpModeLastItem"
@@ -273,6 +274,7 @@ export default {
       helpMode: false,
       helpModeActiveItem: 0,
       helpModeLastItem: false,
+      useHelpModeDialog: true,
       multiflatmapRef: null,
       mapSettings: [],
       //flatmapAPI: "https://mapcore-demo.org/current/flatmap/v2/"

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1260,7 +1260,12 @@ export default {
         this.$emit('help-mode-last-item', true);
       }
 
-      if (helpMode && toolTipsLength > this.helpModeActiveIndex) {
+      if (helpMode && !this.helpModeDialog) {
+        this.inHelp = true;
+        this.hoverVisibilities.forEach((item) => {
+          item.value = true;
+        });
+      } else if (helpMode && this.helpModeDialog && toolTipsLength > this.helpModeActiveIndex) {
 
         // Show the map tooltip as first item
         if (this.helpModeActiveIndex > -1) {
@@ -1733,6 +1738,15 @@ export default {
     helpModeActiveItem: {
       type: Number,
       default: 0,
+    },
+    /**
+     * The option to use helpModeDialog.
+     * On default, `false`, clicking help will show all tooltips.
+     * If `true`, clicking help will show the help-mode-dialog.
+     */
+     helpModeDialog: {
+      type: Boolean,
+      default: false,
     },
     /**
      * The last item of help mode.

--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -67,6 +67,7 @@
       :minZoom="minZoom"
       :helpMode="activeSpecies == key && helpMode"
       :helpModeActiveItem="helpModeActiveItem"
+      :helpModeDialog="helpModeDialog"
       :helpModeInitialIndex="-2"
       @help-mode-last-item="onHelpModeLastItem"
       @shown-tooltip="onTooltipShown"
@@ -541,14 +542,23 @@ export default {
     /**
      * The active item index of help mode.
      */
-     helpModeActiveItem: {
+    helpModeActiveItem: {
       type: Number,
       default: 0,
     },
     /**
+     * The option to use helpModeDialog.
+     * On default, `false`, clicking help will show all tooltips.
+     * If `true`, clicking help will show the help-mode-dialog.
+     */
+    helpModeDialog: {
+      type: Boolean,
+      default: false,
+    },
+    /**
      * The last item of help mode.
      */
-     helpModeLastItem: {
+    helpModeLastItem: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
Copy of the works @akhuoa has done on this repos - https://github.com/ABI-Software/scaffoldvuer/commit/d599e8bc13cc43071db58e9fc54b7809b5bd348c

It supports the old help mode without help mode dialog.