### PR TITLE
UI updates for FC map pathway container

### DIFF
--- a/src/components/TreeControls.vue
+++ b/src/components/TreeControls.vue
@@ -119,6 +119,10 @@ export default {
 
 <style lang="scss" scoped>
 
+.selections-container {
+  padding-top: 5px;
+}
+
 .checkbox-container {
   display: flex;
   cursor: pointer;
@@ -163,6 +167,7 @@ export default {
   background: #ffffff;
   margin-top: 6px;
   scrollbar-width: thin;
+  overflow: hidden;
 
   :deep(.el-tree) {
     max-height: 240px;

--- a/src/components/TreeControls.vue
+++ b/src/components/TreeControls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="selections-container">
     <el-row>
       <el-col :span="12">
         <div class="title-text">Systems</div>


### PR DESCRIPTION
The systems container is causing the additional space in the pathway container.

![2024-05-31_13-53](https://github.com/ABI-Software/flatmapvuer/assets/161257464/d5aa2473-51af-4a82-97cc-955ff5c4307e)

And the additional space on close.

![2024-05-31_13-55](https://github.com/ABI-Software/flatmapvuer/assets/161257464/57d0bb0a-2398-4581-a6c5-c9abd22e65b0)

This update fixes that issue and the systems' tree-controls container border.

