### PR TITLE
Update to Flatmap-viewer version 3.1.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can now use the FlatmapVuer in your vue template as followed:
 NCBITaxon:9606 (Human), NCBITaxon:9685 (Cat), NCBITaxon:9823 (Pig), NCBITaxon:10090 (Mouse) and NCBITaxon:10114 (Rat)
 
 **ready** is the custom event when the map has been loaded successfully.
-**resource-selected** is the custom event triggered when a part of the flatmap is selected, the returned argument **resource** provides information of the selected resource.
+**resource-selected** is the custom event triggered when a part of the flatmap is selected, the returned argument **resource** provides information of the selected resource. Information of location is provided with supported maps in the **feature -> location** property.
 
 Markers must be added to make a label selectable and it can be done through the **addMarker** method on the mapImp member of the FlatmapVuer component.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmap-viewer": "2.9.5",
+        "@abi-software/flatmap-viewer": "3.1.4",
         "@abi-software/map-utilities": "1.1.0",
         "@abi-software/sparc-annotation": "0.3.1",
         "@abi-software/svg-sprite": "1.0.0",
@@ -43,17 +43,20 @@
       }
     },
     "node_modules/@abi-software/flatmap-viewer": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-2.9.5.tgz",
-      "integrity": "sha512-Sib5EghUvNmcTyEc4tuEDSE2UBwnBC+1qaVcaF69auwUBrcEH8A4x0kqjEd6TdUV0XF5rVnbov+addBDgdBEdg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-3.1.4.tgz",
+      "integrity": "sha512-TufhMTpMMbPSI/VxsYgjsBIQ10fwCqruO1m+aHapYdioKQcsBSdhIuib+86Hj6ZKF6dSdkA37NWaMY3YlBV/qw==",
       "dependencies": {
-        "@deck.gl/core": "^8.9.35",
-        "@deck.gl/layers": "^8.9.35",
-        "@deck.gl/mapbox": "^8.9.35",
+        "@deck.gl/core": "^9.0.17",
+        "@deck.gl/geo-layers": "^9.0.18",
+        "@deck.gl/layers": "^9.0.17",
+        "@deck.gl/mapbox": "^9.0.17",
         "@mapbox/mapbox-gl-draw": "^1.4.3",
         "@turf/area": "^6.5.0",
         "@turf/bbox": "^6.5.0",
         "@turf/helpers": "^6.5.0",
+        "@turf/length": "^7.0.0",
+        "@turf/nearest-point-on-line": "^7.0.0",
         "@turf/projection": "^6.5.0",
         "bezier-js": "^6.1.0",
         "colord": "^2.9.3",
@@ -62,7 +65,7 @@
         "graphology-operators": "^1.6.0",
         "graphology-shortest-path": "^2.1.0",
         "html-es6cape": "^2.0.2",
-        "maplibre-gl": ">=4.3.0",
+        "maplibre-gl": ">=4.5.0",
         "mathjax-full": "^3.2.2",
         "minisearch": "^2.2.1",
         "polylabel": "^1.1.0"
@@ -590,58 +593,123 @@
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "8.9.36",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.9.36.tgz",
-      "integrity": "sha512-mkIv4/fY1jE+iehqSJzUQi75l9cgfx2ZBa1s1AifgLu0TCkCZgRgISV3UnDBECDCmTZ9Cqk+oKq3OGay3Bz1RQ==",
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.0.27.tgz",
+      "integrity": "sha512-2lHN9xvQLjcjIfBeWnHIDGhlYfcKkkpzaiNEL5wNiDeF8mIvrHbCwehm24ZhdlEmRFCNfRT6h6swUCp1H3oenQ==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@loaders.gl/core": "^3.4.13",
-        "@loaders.gl/images": "^3.4.13",
-        "@luma.gl/constants": "^8.5.21",
-        "@luma.gl/core": "^8.5.21",
-        "@luma.gl/webgl": "^8.5.21",
-        "@math.gl/core": "^3.6.2",
-        "@math.gl/sun": "^3.6.2",
-        "@math.gl/web-mercator": "^3.6.2",
-        "@probe.gl/env": "^3.5.0",
-        "@probe.gl/log": "^3.5.0",
-        "@probe.gl/stats": "^3.5.0",
+        "@loaders.gl/core": "^4.2.0",
+        "@loaders.gl/images": "^4.2.0",
+        "@luma.gl/constants": "^9.0.15",
+        "@luma.gl/core": "^9.0.15",
+        "@luma.gl/engine": "^9.0.15",
+        "@luma.gl/shadertools": "^9.0.15",
+        "@luma.gl/webgl": "^9.0.15",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/sun": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
+        "@probe.gl/env": "^4.0.9",
+        "@probe.gl/log": "^4.0.9",
+        "@probe.gl/stats": "^4.0.9",
+        "@types/offscreencanvas": "^2019.6.4",
         "gl-matrix": "^3.0.0",
-        "math.gl": "^3.6.2",
         "mjolnir.js": "^2.7.0"
       }
     },
-    "node_modules/@deck.gl/layers": {
-      "version": "8.9.36",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.9.36.tgz",
-      "integrity": "sha512-sr/QKELXZ4W0ZHb12QC2+EV1bZJOM6cU6kAfOJD5jOVixOcyccr+FnPPGn39VK9cl/VFY0S339ZPs9reyhDFVg==",
+    "node_modules/@deck.gl/extensions": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.0.27.tgz",
+      "integrity": "sha512-vR1sgWBWZkgwIr0z87necPqSuOvQgDVQu11nAxLq+zQ0xYk9QD0dmLf4Ve63/EeOM5auATGqhq3PcEsS0y2sKg==",
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@loaders.gl/images": "^3.4.13",
-        "@loaders.gl/schema": "^3.4.13",
-        "@luma.gl/constants": "^8.5.21",
+        "@luma.gl/constants": "^9.0.15",
+        "@luma.gl/shadertools": "^9.0.15",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.0.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
+      }
+    },
+    "node_modules/@deck.gl/geo-layers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.0.27.tgz",
+      "integrity": "sha512-mIlAr6ff8gJTMfyEkmW6JnmuIcP6haUGKYjr5Gk1MP1zA1/cYktQLrZTK6jQhXq7xqSvHsDWkZdO97P639uSXw==",
+      "dependencies": {
+        "@loaders.gl/3d-tiles": "^4.2.0",
+        "@loaders.gl/gis": "^4.2.0",
+        "@loaders.gl/loader-utils": "^4.2.0",
+        "@loaders.gl/mvt": "^4.2.0",
+        "@loaders.gl/schema": "^4.2.0",
+        "@loaders.gl/terrain": "^4.2.0",
+        "@loaders.gl/tiles": "^4.2.0",
+        "@loaders.gl/wms": "^4.2.0",
+        "@luma.gl/gltf": "^9.0.15",
+        "@luma.gl/shadertools": "^9.0.15",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/culling": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
+        "@types/geojson": "^7946.0.8",
+        "h3-js": "^4.1.0",
+        "long": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/extensions": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@deck.gl/mesh-layers": "^9.0.0",
+        "@loaders.gl/core": "^4.2.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
+      }
+    },
+    "node_modules/@deck.gl/layers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.0.27.tgz",
+      "integrity": "sha512-+r8w9J9nHOqZt/2vIUsthz6GzjLnRiVCZvvr9ckxGi9IsibX1DgabIQfZ8vAi1AG4ngGswZA4C2mIB6mTLiO4Q==",
+      "dependencies": {
+        "@loaders.gl/images": "^4.2.0",
+        "@loaders.gl/schema": "^4.2.0",
         "@mapbox/tiny-sdf": "^2.0.5",
-        "@math.gl/core": "^3.6.2",
-        "@math.gl/polygon": "^3.6.2",
-        "@math.gl/web-mercator": "^3.6.2",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/polygon": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
         "earcut": "^2.2.4"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0",
-        "@loaders.gl/core": "^3.4.13",
-        "@luma.gl/core": "^8.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@loaders.gl/core": "^4.2.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/mapbox": {
-      "version": "8.9.36",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.9.36.tgz",
-      "integrity": "sha512-JUMkxHsaV5/FhKx68cp87vcHTdYTqS1fWpytN7I1B0p1gxhd37iYNU/FtEg3Pxs5ce9zLkjVepF6PALVWnDlGw==",
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.0.27.tgz",
+      "integrity": "sha512-s33A8p1jIutSAy1+29U8LuQn+VR84In2bBxunHfYy/8LvkXfqDcuNGmQraV994Ev3SkUv02nR3Adsx4NB1GBfg==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@types/mapbox-gl": "^2.6.3"
+        "@luma.gl/constants": "^9.0.15",
+        "@math.gl/web-mercator": "^4.0.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@luma.gl/core": "^9.0.0"
+      }
+    },
+    "node_modules/@deck.gl/mesh-layers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.0.27.tgz",
+      "integrity": "sha512-+MTKR6+OOl8xL48R/+Q2slJnAVxbfqz5wOH/9miIih96Znnr5BRctkOBdItnrDRqIiNE67f3lq4lzONedsvb3g==",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/gltf": "^4.2.0",
+        "@luma.gl/gltf": "^9.0.15",
+        "@luma.gl/shadertools": "^9.0.15"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.0.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@digitalbazaar/http-client": {
@@ -1302,116 +1370,360 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
     },
-    "node_modules/@loaders.gl/core": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.15.tgz",
-      "integrity": "sha512-rPOOTuusWlRRNMWg7hymZBoFmPCXWThsA5ZYRfqqXnsgVeQIi8hzcAhJ7zDUIFAd/OSR8ravtqb0SH+3k6MOFQ==",
+    "node_modules/@loaders.gl/3d-tiles": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.2.2.tgz",
+      "integrity": "sha512-op7KelDjEahz+ViFmavJdHw10n6lRZeTefC/cVYVQ1Jfvb8T+55KaOOXGoZODo14/B8Z53FnyPGVqR68dBYARw==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.4.15",
-        "@loaders.gl/worker-utils": "3.4.15",
-        "@probe.gl/log": "^3.5.0"
+        "@loaders.gl/compression": "4.2.2",
+        "@loaders.gl/crypto": "4.2.2",
+        "@loaders.gl/draco": "4.2.2",
+        "@loaders.gl/gltf": "4.2.2",
+        "@loaders.gl/images": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/math": "4.2.2",
+        "@loaders.gl/tiles": "4.2.2",
+        "@loaders.gl/zip": "4.2.2",
+        "@math.gl/core": "^4.0.1",
+        "@math.gl/culling": "^4.0.1",
+        "@math.gl/geospatial": "^4.0.1",
+        "@probe.gl/log": "^4.0.4",
+        "long": "^5.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/3d-tiles/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/@loaders.gl/compression": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.2.2.tgz",
+      "integrity": "sha512-dBFjMe4zLhE4NXfVsPkhs267/55qnxgP/AIhksOKTx30gQxCtcty6RWhfWGnluTnbAEXID2Uq/vfp1HYH7ZYCg==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/worker-utils": "4.2.2",
+        "@types/brotli": "^1.3.0",
+        "@types/pako": "^1.0.1",
+        "fflate": "0.7.4",
+        "lzo-wasm": "^0.0.4",
+        "pako": "1.0.11",
+        "snappyjs": "^0.6.1"
+      },
+      "optionalDependencies": {
+        "brotli": "^1.3.2",
+        "lz4js": "^0.2.0",
+        "zstd-codec": "^0.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/core": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.2.2.tgz",
+      "integrity": "sha512-d3YElSsqL29MaiOwzGB97v994SPotbTvJnooCqoQsYGoYYrECdIetv1/zlfDsh5UB2Wl/NaUMJrzyOqlLmDz5Q==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@loaders.gl/worker-utils": "4.2.2",
+        "@probe.gl/log": "^4.0.2"
+      }
+    },
+    "node_modules/@loaders.gl/crypto": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.2.2.tgz",
+      "integrity": "sha512-0rbpHX8784wkcTb8+gjkzAxdA4p2CH3W5xxzdvpG4r37jVQwKYrh2NJxeF+xGIuuxlEaxD8x4kcyadKgCVtspA==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/worker-utils": "4.2.2",
+        "@types/crypto-js": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/draco": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.2.2.tgz",
+      "integrity": "sha512-WM7Zw6+04QzqlXjUYibR63Zi4I2iuBaDR41Rguur1s+ns2faiHDyEvuFlKtArTChFPQ8Xzf+6MNt7JeR8kpZTA==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@loaders.gl/worker-utils": "4.2.2",
+        "draco3d": "1.5.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/gis": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.2.2.tgz",
+      "integrity": "sha512-s9kD6yLMKn8+jAhDFDVWBeeKcDkJHFrscTnVWveGBfnC7IYT4gD6lQeHRIfXrJKs0LWmKPrAS8grTq7Ull8V6Q==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@math.gl/polygon": "^4.0.0",
+        "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/gltf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.2.2.tgz",
+      "integrity": "sha512-AK90PnRoaZ1jw/QWkg6TEJG8Yxd/QefxwlbMRJvtgk7QafsYo8dMm0e7EYgyOms0wDOcPflm5LHkIoqViRp/ww==",
+      "dependencies": {
+        "@loaders.gl/draco": "4.2.2",
+        "@loaders.gl/images": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@loaders.gl/textures": "4.2.2",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.15.tgz",
-      "integrity": "sha512-QpjYhEetHabY/z9mWZYJXZZp4XJAxa38f9Ii/DjPlnJErepzY5GLBUTDHMu4oZ6n99gGImtuGFicDnFV6mb60g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.2.2.tgz",
+      "integrity": "sha512-R53rkexvVT0i4YXt++r8gLq3reB6kWTLvdJL81J3R4YJbM5+kNSe40jJOA94LFYlsTN+oirF4lkLTe5YXGZPYQ==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.4.15"
+        "@loaders.gl/loader-utils": "4.2.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.15.tgz",
-      "integrity": "sha512-uUx6tCaky6QgCRkqCNuuXiUfpTzKV+ZlJOf6C9bKp62lpvFOv9AwqoXmL23j8nfsENdlzsX3vPhc3en6QQyksA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.2.2.tgz",
+      "integrity": "sha512-5udJQhFx1KNIcRBYkFMi8QZitAsK+m3PkZ9GejM8VpOSsJUHD2Yal3wBHOPTRsOjQ0zXG/nqM7BHOojjeetNTg==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.4.15",
-        "@probe.gl/stats": "^3.5.0"
+        "@loaders.gl/schema": "4.2.2",
+        "@loaders.gl/worker-utils": "4.2.2",
+        "@probe.gl/stats": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/math": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.2.2.tgz",
+      "integrity": "sha512-nfiNNxXobhdKJILlHDWvm92SMEMMh1XAsb4BYvRIHyTzw4KzflFMS6C62v8ctAW6P8pQKyRvuos9LcRyroty1A==",
+      "dependencies": {
+        "@loaders.gl/images": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/mvt": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.2.2.tgz",
+      "integrity": "sha512-KglhYp1rwIs6h6AtrmKjrEYWxcX6xhlG3c3pTIFJwfA5nMBa+cmzD19vBRo1po9hzWKq4oqqhi7JL0ovH6GAqw==",
+      "dependencies": {
+        "@loaders.gl/gis": "4.2.2",
+        "@loaders.gl/images": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@math.gl/polygon": "^4.0.0",
+        "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.15.tgz",
-      "integrity": "sha512-8oRtstz0IsqES7eZd2jQbmCnmExCMtL8T6jWd1+BfmnuyZnQ0B6TNccy++NHtffHdYuzEoQgSELwcdmhSApYew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.2.2.tgz",
+      "integrity": "sha512-vrQ6vlGWWptJXDP1DrL5x/j70xmyt2l36QZcGyDYptrohTGvQLc3yrOEHuD5v96fXX5WR619pT3zSYhuf1FnIg==",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/terrain": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.2.2.tgz",
+      "integrity": "sha512-M5wDS20y0TTq9giCONLOWSIznD9H4JxfU1wicyEGUOa8U2u0Fdau5TObr//fOcT+Tvemkvcn01Oxj8acJWIsGw==",
+      "dependencies": {
+        "@loaders.gl/images": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@mapbox/martini": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/textures": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.2.2.tgz",
+      "integrity": "sha512-UlxCCi7VbCloj4VCzSULASgGVA059jglQYLc3kIHclvGoMcx3MJi0hID0MEQ6IhdO9Zyn4F42doVPrriNDVJFQ==",
+      "dependencies": {
+        "@loaders.gl/images": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@loaders.gl/worker-utils": "4.2.2",
+        "@math.gl/types": "^4.0.1",
+        "ktx-parse": "^0.0.4",
+        "texture-compressor": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/tiles": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.2.2.tgz",
+      "integrity": "sha512-mozBA1FOrOFXa0lBxrRvHoRxsSb9T8D6ZfFIpbVR1z0zEWKm+NgRQzO8yS4IJD/CPFOn/r31SolZII6yXnzWbg==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/math": "4.2.2",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/culling": "^4.0.0",
+        "@math.gl/geospatial": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
+        "@probe.gl/stats": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.2.2.tgz",
+      "integrity": "sha512-MoZqOgebyXsElfNbjX/el4jA9Rypusq7Z+cJ1tiP2yBTepuLkPBpXLeuUgt/v0MOqGoUWrkUY8I811ijkZYyjA==",
+      "dependencies": {
+        "@loaders.gl/images": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "@loaders.gl/xml": "4.2.2",
+        "@turf/rewind": "^5.1.5",
+        "deep-strict-equal": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "3.4.15",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.15.tgz",
-      "integrity": "sha512-zUUepOYRYmcYIcr/c4Mchox9h5fBFNkD81rsGnLlZyq19QvyHzN+93SVxrLc078gw93t2RKrVcOOZY13zT3t1w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.2.2.tgz",
+      "integrity": "sha512-7Ad83VS/PmS0T3LXo+LB6cq5oHhAUW3GvYWizm4OfeuBDQRtYK7iRehgC13/BomkNtWIn0y7iAphlQMVrNdvhQ==",
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/xml": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.2.2.tgz",
+      "integrity": "sha512-ADikkGCwkS6d2IwFPomVAZfTNEHC6xXqDFbzfhYThsG3ptPpeosjJmn4GdI4dyazTsQnKIeiqV/RLS4CvJgxzw==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1"
+        "@loaders.gl/loader-utils": "4.2.2",
+        "@loaders.gl/schema": "4.2.2",
+        "fast-xml-parser": "^4.2.5"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/zip": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.2.2.tgz",
+      "integrity": "sha512-8wuhWrmGFUb9X7i1E9ObhqyiYuwQj6x0ttzujXE6o83T8TI1i88fySttMe0LSV2aIrTLo8A5n6MOf2LPSefPYg==",
+      "dependencies": {
+        "@loaders.gl/compression": "4.2.2",
+        "@loaders.gl/crypto": "4.2.2",
+        "@loaders.gl/loader-utils": "4.2.2",
+        "jszip": "^3.1.5",
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@luma.gl/constants": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.21.tgz",
-      "integrity": "sha512-aJxayGxTT+IRd1vfpcgD/cKSCiVJjBNiuiChS96VulrmCvkzUOLvYXr42y5qKB4RyR7vOIda5uQprNzoHrhQAA=="
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.0.24.tgz",
+      "integrity": "sha512-lq8irv1r6g9We/+Hufuw2aFbSo/ulUJ6awhpKKCgYTUr4AuPd/t13+GaNqyHfge9SOhhqaErbkKNoW1C59IPow=="
     },
     "node_modules/@luma.gl/core": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.21.tgz",
-      "integrity": "sha512-11jQJQEMoR/IN2oIsd4zFxiQJk6FE+xgVIMUcsCTBuzafTtQZ8Po9df8mt+MVewpDyBlTVs6g8nxHRH4np1ukA==",
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.0.24.tgz",
+      "integrity": "sha512-zUJTInY/1dfl61K+oiSy8a9wOv7R6OJUsVfiZYFOHDjMQx6vHY1CYL9r+Wr0jdn2doEsSN2jCCGuBLLX+z4Y6Q==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@luma.gl/engine": "8.5.21",
-        "@luma.gl/gltools": "8.5.21",
-        "@luma.gl/shadertools": "8.5.21",
-        "@luma.gl/webgl": "8.5.21"
+        "@math.gl/types": "^4.0.0",
+        "@probe.gl/env": "^4.0.2",
+        "@probe.gl/log": "^4.0.2",
+        "@probe.gl/stats": "^4.0.2",
+        "@types/offscreencanvas": "^2019.6.4"
       }
     },
     "node_modules/@luma.gl/engine": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.21.tgz",
-      "integrity": "sha512-IG3WQSKXFNUEs8QG7ZjHtGiOtsakUu+BAxtJ6997A6/F06yynZ44tPe5NU70jG9Yfu3kV0LykPZg7hO3vXZDiA==",
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.0.24.tgz",
+      "integrity": "sha512-tnYaabQAUHIg4gNidX4tzHOrwy7yHZcekIo43un1BeD4396JvqdojU4Q3W9Rhy/h1ViLYo7LOJ6aEFgoFgEuew==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@luma.gl/gltools": "8.5.21",
-        "@luma.gl/shadertools": "8.5.21",
-        "@luma.gl/webgl": "8.5.21",
-        "@math.gl/core": "^3.5.0",
-        "@probe.gl/env": "^3.5.0",
-        "@probe.gl/stats": "^3.5.0",
-        "@types/offscreencanvas": "^2019.7.0"
+        "@luma.gl/shadertools": "9.0.24",
+        "@math.gl/core": "^4.0.0",
+        "@probe.gl/log": "^4.0.2",
+        "@probe.gl/stats": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "^9.0.0"
       }
     },
-    "node_modules/@luma.gl/gltools": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.21.tgz",
-      "integrity": "sha512-6qZ0LaT2Mxa4AJT5F44TFoaziokYiHUwO45vnM/NYUOIu9xevcmS6VtToawytMEACGL6PDeDyVqP3Y80SDzq5g==",
+    "node_modules/@luma.gl/gltf": {
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.0.24.tgz",
+      "integrity": "sha512-BGVF3Oatsjod2d2Q6Aoc7To9rHfEINyWnel1lYu/DDe0G0zcJHFXVbK0KZ7J+ibd4d6vL1U6NdFTJ+FRhQ5/uQ==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@probe.gl/env": "^3.5.0",
-        "@probe.gl/log": "^3.5.0",
-        "@types/offscreencanvas": "^2019.7.0"
+        "@loaders.gl/textures": "^4.2.0",
+        "@luma.gl/shadertools": "9.0.24",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.2.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@luma.gl/shadertools": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.21.tgz",
-      "integrity": "sha512-WQah7yFDJ8cNCLPYpIm3r0wSlXLvjoA279fcknmATvvkW3/i8PcCJ/nYEBJO3hHEwwMQxD16+YZu/uwGiifLMg==",
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.0.24.tgz",
+      "integrity": "sha512-qdzHFlfELx7OCKwyq7OKZ9sVYDN6GJPcrquqLmqEIthiRxHRn9f7y3eZUJeIviSMiQmNrZcFx+c+YlIlDBfFVA==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@math.gl/core": "^3.5.0"
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/types": "^4.0.0",
+        "wgsl_reflect": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "^9.0.0"
       }
     },
     "node_modules/@luma.gl/webgl": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.21.tgz",
-      "integrity": "sha512-ZVLO4W5UuaOlzZIwmFWhnmZ1gYoU97a+heMqxLrSSmCUAsSu3ZETUex9gOmzdM1WWxcdWaa3M68rvKCNEgwz0Q==",
+      "version": "9.0.24",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.0.24.tgz",
+      "integrity": "sha512-fs5HWM24pSuSzSGSPnmB0TeIc15hoXwkXA8wKaa3/zIUEGbqbvOFUQIuTs+xEki6Yo5fuXMZbwBqPizEHj+MVQ==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@luma.gl/gltools": "8.5.21",
-        "@probe.gl/env": "^3.5.0",
-        "@probe.gl/stats": "^3.5.0"
+        "@luma.gl/constants": "9.0.24",
+        "@probe.gl/env": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "^9.0.0"
       }
     },
     "node_modules/@mapbox/extent": {
@@ -1503,6 +1815,11 @@
         "xtend": "^4.0.2"
       }
     },
+    "node_modules/@mapbox/martini": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/martini/-/martini-0.2.0.tgz",
+      "integrity": "sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ=="
+    },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
@@ -1535,9 +1852,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.0.tgz",
-      "integrity": "sha512-eSiQ3E5LUSxAOY9ABXGyfNhout2iEa6mUxKeaQ9nJ8NL1NuaQYU7zKqzx/LEYcXe1neT4uYAgM1wYZj3fTSXtA==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.1.tgz",
+      "integrity": "sha512-5ueL4UDitzVtceQ8J4kY+Px3WK+eZTsmGwha3MBKHKqiHvKrjWWwBCIl1K8BuJSc5OFh83uI8IFNoFvQxX2uUw==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
@@ -1546,7 +1863,7 @@
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
         "sort-object": "^3.0.3",
-        "tinyqueue": "^2.0.3"
+        "tinyqueue": "^3.0.0"
       },
       "bin": {
         "gl-style-format": "dist/gl-style-format.mjs",
@@ -1554,50 +1871,67 @@
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
+    },
     "node_modules/@math.gl/core": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
-      "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.0.1.tgz",
+      "integrity": "sha512-9IewNjR9V66o+gYIIq5agFoHy6ZT6DRpRGQBfsUpZz4glAqOjVt64he8GGzjpmqfT+kKT4qwQ7nQl/hZLF15qA==",
       "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "@math.gl/types": "3.6.3",
-        "gl-matrix": "^3.4.0"
+        "@math.gl/types": "4.0.1"
+      }
+    },
+    "node_modules/@math.gl/culling": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-4.0.1.tgz",
+      "integrity": "sha512-lv83sMKp0n1HjORhuNtWgX9ylYyj+/zHEPF0xxRXZvcpurB85fhgFLhvR81KLjmSbhQmFgzl0fZe7Ei3WxEP5Q==",
+      "dependencies": {
+        "@math.gl/core": "4.0.1"
+      }
+    },
+    "node_modules/@math.gl/geospatial": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-4.0.1.tgz",
+      "integrity": "sha512-FfTUMk8uRlBa4W3dMSFwPjRgdEBnOeVjBr3mcGqb3lHA/PPMvKuE+o7OJfA61Wj6ItuZqCEZHbLbA3WRAENoqQ==",
+      "dependencies": {
+        "@math.gl/core": "4.0.1"
       }
     },
     "node_modules/@math.gl/polygon": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
-      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.0.1.tgz",
+      "integrity": "sha512-pwtEbwW3N5qy09K/1FwRYW7M2u9XMPBfIe8BNpkbJh8uH3DPXQdT4uCNFiwrQPPQUQTDdlQyLu/0mRHm2R/fbg==",
       "dependencies": {
-        "@math.gl/core": "3.6.3"
+        "@math.gl/core": "4.0.1"
       }
     },
     "node_modules/@math.gl/sun": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/sun/-/sun-3.6.3.tgz",
-      "integrity": "sha512-mrx6CGYYeTNSQttvcw0KVUy+35YDmnjMqpO/o0t06Vcghrt0HNruB/ScRgUSbJrgkbOg1Vcqm23HBd++clzQzw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/sun/-/sun-4.0.1.tgz",
+      "integrity": "sha512-nDkQZ9PKd5iMySRM1j01hYG6MwA/MkKXZe4JvArggWUtPXL6nCcPSeiifPXQGIvE9eZdQkbn81StNY9q5l0cFg=="
     },
     "node_modules/@math.gl/types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
-      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.0.1.tgz",
+      "integrity": "sha512-E9qBKAjVBiZD8Is7TbygiLGtYBP3GSLus6RUJSuzFQegdYXeVagvrs4UkBJxhrRAxw4crfH0Tq7IhTMKuuJNQw=="
     },
     "node_modules/@math.gl/web-mercator": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
-      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "gl-matrix": "^3.4.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.0.1.tgz",
+      "integrity": "sha512-eJ0nDw8140kJorf8ASyKRC53rI+UG6vPxpsKJiGRD6lXsoKTeKYebeEAXiGDWTvi2AMe6+xngxTqqwm58fL3Fw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1642,29 +1976,22 @@
       }
     },
     "node_modules/@probe.gl/env": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-3.6.0.tgz",
-      "integrity": "sha512-4tTZYUg/8BICC3Yyb9rOeoKeijKbZHRXBEKObrfPmX4sQmYB15ZOUpoVBhAyJkOYVAM8EkPci6Uw5dLCwx2BEQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.0.9.tgz",
+      "integrity": "sha512-AOmVMD0/j78mX+k4+qX7ZhE0sY9H+EaJgIO6trik0BwV6VcrwxTGCGFAeuRsIGhETDnye06tkLXccYatYxAYwQ=="
     },
     "node_modules/@probe.gl/log": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-3.6.0.tgz",
-      "integrity": "sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.0.9.tgz",
+      "integrity": "sha512-ebuZaodSRE9aC+3bVC7cKRHT8garXeT1jTbj1R5tQRqQYc9iGeT3iemVOHx5bN9Q6gAs/0j54iPI+1DvWMAW4A==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/env": "3.6.0"
+        "@probe.gl/env": "4.0.9"
       }
     },
     "node_modules/@probe.gl/stats": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.6.0.tgz",
-      "integrity": "sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.9.tgz",
+      "integrity": "sha512-Q9Xt/sJUQaMsbjRKjOscv2t7wXIymTrOEJ4a3da4FTCn7bkKvcdxdyFAQySCrtPxE+YZ5I5lXpWPgv9BwmpE1g=="
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.0",
@@ -1934,12 +2261,112 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/bearing": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.1.0.tgz",
+      "integrity": "sha512-X5lackrZ6FW+YhgjWxwVFRgWD1j4xm4t5VvE6EE6v/1PVaHQ5OCjf6u1oaLx5LSG+gaHUhjTlAHrn9MYPFaeTA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing/node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise/node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+    },
+    "node_modules/@turf/boolean-clockwise/node_modules/@turf/invariant": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+      "integrity": "sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
     "node_modules/@turf/clone": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.5.0.tgz",
       "integrity": "sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==",
       "dependencies": {
         "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.1.0.tgz",
+      "integrity": "sha512-97XuvB0iaAiMg86hrnZ529WwP44TQAA9mmI5PMlchACiA4LFrEtWjjDzvO6234coieoqhrw6dZYcJvd5O2PwrQ==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination/node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.1.0.tgz",
+      "integrity": "sha512-hhNHhxCHB3ddzAGCNY4BtE29OZh+DAJPvUapQz+wOjISnlwvMcwLKvslgHWSYF536QDVe/93FEU2q67+CsZTPA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance/node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -1953,12 +2380,145 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/invariant": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.1.0.tgz",
+      "integrity": "sha512-OCLNqkItBYIP1nE9lJGuIUatWGtQ4rhBKAyTfFu0z8npVzGEYzvguEeof8/6LkKmTTEHW53tCjoEhSSzdRh08Q==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant/node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.1.0.tgz",
+      "integrity": "sha512-wUJj9WLKEudG1ngNao2ZwD+Dt6UkvWIbubuJ6lR6FndFDL3iezFhNGy0IXS+0xH9kXi2apiTnM9Vk5+i8BTEvQ==",
+      "dependencies": {
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length/node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length/node_modules/@turf/meta": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.1.0.tgz",
+      "integrity": "sha512-JI3dvOsAoCqd4vUJ134FIzgcC42QpC/tBs+b4OJoxWmwDek3REv4qGaZY6wCg9X4hFSlCKFcnhMIQQZ/n720Qg==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect/node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/meta": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
       "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
       "dependencies": {
         "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.1.0.tgz",
+      "integrity": "sha512-aTjAOm7ab0tl5JoxGYRx/J/IbRL1DY1ZCIYQDMEQjK5gOllhclgeBC0wDXDkEZFGaVftjw0W2RtE2I0jX7RG4A==",
+      "dependencies": {
+        "@turf/bearing": "^7.1.0",
+        "@turf/destination": "^7.1.0",
+        "@turf/distance": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@turf/line-intersect": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line/node_modules/@turf/helpers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line/node_modules/@turf/meta": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
+      "dependencies": {
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -1977,6 +2537,47 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rewind/node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rewind/node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+    },
+    "node_modules/@turf/rewind/node_modules/@turf/invariant": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+      "integrity": "sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rewind/node_modules/@turf/meta": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+      "integrity": "sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -1992,6 +2593,14 @@
       "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
       "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/brotli": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/brotli/-/brotli-1.3.4.tgz",
+      "integrity": "sha512-cKYjgaS2DMdCKF7R0F5cgx1nfBYObN2ihIuPGQ4/dlIY6RpV7OWNwe9L8V4tTVKL2eZqOkNM9FM/rgTvLf4oXw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2014,6 +2623,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
     },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
@@ -2121,11 +2735,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
-    "node_modules/@types/junit-report-builder": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
-      "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA=="
-    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -2160,14 +2769,6 @@
         "@types/pbf": "*"
       }
     },
-    "node_modules/@types/mapbox-gl": {
-      "version": "2.7.21",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.21.tgz",
-      "integrity": "sha512-Dx9MuF2kKgT/N22LsMUB4b3acFZh9clVqz9zv1fomoiPoBrJolwYxpWA/9LPO/2N0xWbKi4V+pkjTaFkkx/4wA==",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/markdown-it": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -2194,7 +2795,6 @@
       "version": "20.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
       "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2212,6 +2812,11 @@
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
+    },
+    "node_modules/@types/pako": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.7.tgz",
+      "integrity": "sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A=="
     },
     "node_modules/@types/pbf": {
       "version": "3.0.5",
@@ -3690,6 +4295,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -3728,6 +4342,14 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buf-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/buffer": {
@@ -3905,6 +4527,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/check-more-types": {
@@ -4325,6 +4955,18 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
+    "node_modules/core-assert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw==",
+      "dependencies": {
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.37.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
@@ -4338,8 +4980,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
@@ -4360,6 +5001,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/css-element-queries": {
@@ -4723,6 +5372,17 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "node_modules/deep-strict-equal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+      "integrity": "sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA==",
+      "dependencies": {
+        "core-assert": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-gateway": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -4959,6 +5619,11 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ=="
     },
     "node_modules/earcut": {
       "version": "2.2.4",
@@ -6296,6 +6961,27 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -6346,6 +7032,11 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -6633,9 +7324,9 @@
       "integrity": "sha512-k/6BCd0qAt7vdqdM1LkLfAy72EsLDy0laNwX0x2h49vfYCiQkRc4PSra8DNEdJ10EKRpwEvDXMb0dBknTJuWpQ=="
     },
     "node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -6949,6 +7640,16 @@
       "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
       "peerDependencies": {
         "graphology-types": ">=0.23.0"
+      }
+    },
+    "node_modules/h3-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.1.0.tgz",
+      "integrity": "sha512-LQhmMl1dRQQjMXPzJc7MpZ/CqPOWWuAvVEoVJM9n/s7vHypj+c3Pd5rLQCkAsOgAoAYKbNCsYFE++LF7MvSfCQ==",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
       }
     },
     "node_modules/hammerjs": {
@@ -7490,6 +8191,22 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/immutable": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
@@ -7645,6 +8362,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -7721,6 +8443,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-error": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
+      "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg=="
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
@@ -8264,6 +8991,49 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
@@ -8284,6 +9054,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ktx-parse": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.0.4.tgz",
+      "integrity": "sha512-LY3nrmfXl+wZZdPxgJ3ZmLvG+wkOZZP3/dr4RbQj1Pk3Qwz44esOOSFFVQJcNWpXAtiNIC66WgXufX/SYgYz6A=="
     },
     "node_modules/ky": {
       "version": "0.33.3",
@@ -8366,6 +9141,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/listr2": {
@@ -8705,6 +9488,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8736,6 +9527,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/lz4js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
+      "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
+      "optional": true
+    },
+    "node_modules/lzo-wasm": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/lzo-wasm/-/lzo-wasm-0.0.4.tgz",
+      "integrity": "sha512-VKlnoJRFrB8SdJhlVKvW5vI1gGwcZ+mvChEXcSX6r2xDNc/Q2FD9esfBmGCuPZdrJ1feO+YcVFd2PTk0c137Gw=="
+    },
     "node_modules/magic-string": {
       "version": "0.30.10",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
@@ -8745,9 +9547,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.3.2.tgz",
-      "integrity": "sha512-/oXDsb9I+LkjweL/28aFMLDZoIcXKNEhYNAZDLA4xgTNkfvKQmV/r0KZdxEMcVthincJzdyc6Y4N8YwZtHKNnQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.2.tgz",
+      "integrity": "sha512-vlWL9EY2bSGg5FAt0mKPfYqlfX15uLW5D3kKv4Xjn54nIVn01MKdfUJMAVIr+8fXVqfSX6c095Iy5XnV+T76kQ==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -8756,25 +9558,24 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.2.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.0",
         "@types/geojson": "^7946.0.14",
         "@types/geojson-vt": "3.2.5",
-        "@types/junit-report-builder": "^3.0.2",
         "@types/mapbox__point-geometry": "^0.1.4",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
-        "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^3.0.0",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
+        "pbf": "^3.3.0",
         "potpack": "^2.0.0",
-        "quickselect": "^2.0.0",
+        "quickselect": "^3.0.0",
         "supercluster": "^8.0.1",
-        "tinyqueue": "^2.0.3",
+        "tinyqueue": "^3.0.0",
         "vt-pbf": "^3.1.3"
       },
       "engines": {
@@ -8785,19 +9586,21 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
+    "node_modules/maplibre-gl/node_modules/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg=="
+    },
+    "node_modules/maplibre-gl/node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
+    },
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true
-    },
-    "node_modules/math.gl": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.6.3.tgz",
-      "integrity": "sha512-Yq9CyECvSDox9+5ETi2+x1bGTY5WvGUGL3rJfC4KPoCZAM51MGfrCm6rIn4yOJUVfMPs2a5RwMD+yGS/n1g3gg==",
-      "dependencies": {
-        "@math.gl/core": "3.6.3"
-      }
     },
     "node_modules/mathjax-full": {
       "version": "3.2.2",
@@ -8808,6 +9611,16 @@
         "mhchemparser": "^4.1.0",
         "mj-context-menu": "^0.6.1",
         "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {
@@ -9948,6 +10761,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -10049,9 +10867,9 @@
       "dev": true
     },
     "node_modules/pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -10333,8 +11151,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10444,9 +11261,9 @@
       ]
     },
     "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -11327,6 +12144,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/snappyjs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
+      "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg=="
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -11604,6 +12426,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -11834,6 +12661,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -11863,6 +12695,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
       }
     },
     "node_modules/tabbable": {
@@ -11968,6 +12808,26 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+    },
+    "node_modules/texture-compressor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/texture-compressor/-/texture-compressor-1.0.2.tgz",
+      "integrity": "sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig==",
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "image-size": "^0.7.4"
+      },
+      "bin": {
+        "texture-compressor": "bin/texture-compressor.js"
+      }
+    },
+    "node_modules/texture-compressor/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/throttleit": {
       "version": "1.0.1",
@@ -12101,8 +12961,7 @@
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -12300,8 +13159,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -12479,8 +13337,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/util.promisify": {
       "version": "1.0.0",
@@ -13209,6 +14066,11 @@
       "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
       "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ=="
     },
+    "node_modules/wgsl_reflect": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.0.9.tgz",
+      "integrity": "sha512-NgO7ApUnFuB3FTsBVYjWizMIM5qOawlkSsi7j5BsYlMAW/e+j5IgB2M9kdKzR5lgUECFDSZZK3zdJ4yDmjfx4Q=="
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -13546,6 +14408,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zstd-codec": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/zstd-codec/-/zstd-codec-0.1.5.tgz",
+      "integrity": "sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==",
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "./src/*": "./src/*"
   },
   "dependencies": {
-    "@abi-software/flatmap-viewer": "2.9.5",
+    "@abi-software/flatmap-viewer": "3.1.4",
     "@abi-software/map-utilities": "1.1.0",
     "@abi-software/sparc-annotation": "0.3.1",
     "@abi-software/svg-sprite": "1.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -261,6 +261,10 @@ export default {
           iconClass: 'mapicon-icon_cat',
           displayWarning: true,
         },
+        Vagus: {
+          taxo: 'UBERON:1759',
+          displayWarning: true,
+        },
         Sample: { taxo: 'NCBITaxon:1', displayWarning: true },
         'Functional Connectivity': {
           taxo: 'FunctionalConnectivity',
@@ -283,8 +287,9 @@ export default {
       mapSettings: [],
       //flatmapAPI: "https://mapcore-demo.org/current/flatmap/v2/"
       //flatmapAPI: "https://mapcore-demo.org/devel/flatmap/v3/"
-      //flatmapAPI: "https://mapcoe-demo.org/current/flatmap/v3/",
-      flatmapAPI: 'https://mapcore-demo.org/devel/flatmap/v4/',
+      flatmapAPI: "https://mapcore-demo.org/current/flatmap/v3/",
+      //flatmapAPI: 'https://mapcore-demo.org/devel/flatmap/v4/',
+      //flatmapAPI: 'https://mapcore-demo.org/curation/flatmap/',
       //flatmapAPI: "https://mapcore-demo.org/fccb/flatmap/"
       //flatmapAPI: "https://mapcore-demo.org/staging/flatmap/v1/"
       // flatmapAPI: "https://mapcore-demo.org/devel/flatmap/v1/",

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -245,7 +245,7 @@ Please use `const` to assign meaningful names to them...
           <div
             class="pathway-location"
             :class="{ open: drawerOpen, close: !drawerOpen }"
-            v-show="!disableUI"
+            v-show="!(disableUI || isCentreLine)"
           >
             <div
               class="pathway-container"
@@ -377,7 +377,7 @@ Please use `const` to assign meaningful names to them...
                 key="taxonSelection"
               />
               <selections-group
-                v-if="!isFC && centreLines && centreLines.length > 0"
+                v-if="!(isCentreLine || isFC)  && centreLines && centreLines.length > 0"
                 title="Nerves"
                 labelKey="label"
                 identifierKey="key"
@@ -2314,13 +2314,18 @@ export default {
     onFlatmapReady: function () {
       // onFlatmapReady is used for functions that need to run immediately after the flatmap is loaded
       this.sensor = markRaw(new ResizeSensor(this.$refs.display, this.mapResize))
-      if (this.mapImp.options && this.mapImp.options.style === 'functional') {
+      console.log(this.mapImp.options)
+      if (this.mapImp.options?.style === 'functional') {
         this.isFC = true
+      } else if (this.mapImp.options?.style === 'centreline') {
+        this.isCentreLine = true
       }
       this.mapImp.setBackgroundOpacity(1)
       this.backgroundChangeCallback(this.currentBackground)
       this.pathways = this.mapImp.pathTypes()
-      this.mapImp.enableCentrelines(false)
+      if (!this.isCentreLine) {
+        this.mapImp.enableCentrelines(false)
+      }
       //Disable layers for now
       //this.layers = this.mapImp.getLayers();
       this.processSystems(this.mapImp.getSystems())
@@ -2329,7 +2334,7 @@ export default {
       this.addResizeButtonToMinimap()
       this.loading = false
       this.computePathControlsMaximumHeight()
-      this.drawerOpen = true
+      this.drawerOpen = !this.isCentreLine      
       this.mapResize()
       this.handleMapClick();
       /**
@@ -2672,6 +2677,7 @@ export default {
       helpModeActiveIndex: this.helpModeInitialIndex,
       yellowstar: yellowstar,
       isFC: false,
+      isCentreLine: false,
       inHelp: false,
       currentBackground: 'white',
       availableBackground: ['white', 'lightskyblue', 'black'],


### PR DESCRIPTION
Update flatmap-viewer to version 3.14. which now support the new vagus nerve and include location when selecting the resource on the vagus nerve.  