### PR TITLE
Remove error log from abortController

### DIFF
--- a/src/services/flatmapQueries.js
+++ b/src/services/flatmapQueries.js
@@ -256,7 +256,11 @@ let FlatmapQueries = function () {
           }
         })
         .catch((error) => {
-          console.error('Error:', error)
+          if (error.name === 'AbortError') {
+            // This error is from AbortController's abort method.
+          } else {
+            console.error('Error:', error)
+          }
           resolve(false)
         })
     })


### PR DESCRIPTION
Removing the error log from AbortController since this request abort is on purpose; however, when the user sees the error in the console log, it misleads them as an error.