### PR TITLE
UI Updates

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2917,12 +2917,14 @@ export default {
 .pathway-location {
   position: absolute;
   bottom: 0px;
+  left: 0px;
+  transform: translateX(0);
   transition: all var(--el-transition-duration);
   &.open {
-    left: 0px;
+    transform: translateX(0);
   }
   &.close {
-    left: -309px;
+    transform: translateX(-100%);
   }
 }
 
@@ -3498,6 +3500,7 @@ export default {
     }
   }
   &.close {
+    transform: translateX(22px); // button + border width
     i {
       transform: rotate(180deg) scaleY(2);
     }

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2922,7 +2922,7 @@ export default {
     left: 0px;
   }
   &.close {
-    left: -298px;
+    left: -309px;
   }
 }
 
@@ -2940,6 +2940,8 @@ export default {
   text-align: left;
   overflow: auto;
   border: 1px solid rgb(220, 223, 230);
+  border-left: 0;
+  border-bottom: 0;
   padding-bottom: 16px;
   background: #ffffff;
   overflow-x: hidden;


### PR DESCRIPTION
This UI fix is for the gap on the left of the pathway container close button. 

The gap appears because of the scrollbar inside the pathway container. Without a scrollbar, there is no gap for the close button. The scrollbar is dynamic, and it depends on the content inside. 

The fix replaces the fixed width (-298px) with the container's width (100%) and uses CSS transform.

Before
<img src="https://github.com/user-attachments/assets/647de32c-a8b5-4880-b341-b0777db9cb1e" alt="screenshot" width="300" />


After
<img src="https://github.com/user-attachments/assets/46811b53-f5f5-4baf-a96d-c092b361bb11" alt="screenshot" width="300" />

