### PR TITLE
Update vagus flatmap UBERON identifier

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -271,7 +271,7 @@ export default {
           displayWarning: true,
         },
         Vagus: {
-          taxo: 'UBERON:1759',
+          taxo: 'UBERON:0001759',
           displayWarning: true,
         },
         Sample: { taxo: 'NCBITaxon:1', displayWarning: true },


### PR DESCRIPTION
The id `UBERON:1759` was in fact an invalid UBERON identifier — it’s been corrected to `UBERON:0001759`.