### PR TITLE
Fix #202 pathways container zindex

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2920,6 +2920,8 @@ export default {
   left: 0px;
   transform: translateX(0);
   transition: all var(--el-transition-duration);
+  z-index: 99;
+
   &.open {
     transform: translateX(0);
   }


### PR DESCRIPTION
This PR is the fix for https://github.com/ABI-Software/flatmapvuer/issues/202. (When a tooltip is displayed, and the map is moved, it appears above the pathways container. The pathways container should have a higher z-index.)