### PR TITLE
Update species select UI to fit content width

### DIFF
--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -752,9 +752,6 @@ export default {
 }
 
 .select-box {
-  width: 120px;
-  border-radius: 4px;
-  border: 1px solid rgb(144, 147, 153);
   background-color: var(--white);
   font-weight: 500;
   color: rgb(48, 49, 51);
@@ -766,6 +763,27 @@ export default {
     padding-top: 0.25em;
   }
   :deep() {
+    .el-select__wrapper {
+      position: relative;
+      width: fit-content;
+      box-shadow: none;
+      border-radius: 4px;
+      border: 1px solid var(--el-border-color);
+      &.is-focused {
+        border-color: $app-primary-color;
+      }
+    }
+    .el-select__selection {
+      width: fit-content;
+      position: relative;
+    }
+    .el-select__placeholder {
+      position: relative;
+      top: auto;
+      transform: none;
+      min-width: 80px;
+      width: fit-content;
+    }
     .el-input {
       .el-input__wrapper{
         &is-focus,


### PR DESCRIPTION
1. Fix the species content cut-off issue.
2. Update the select box border style to be consistent with other components.

<table>
<tr>
<td>Content cut-off</td>
<td>Full content is visible</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/6c2ca30a-0da1-4f57-adb0-910f2f5244eb" width="200" /></td>
<td>
<img src="https://github.com/user-attachments/assets/b348828a-6007-4aa0-a093-57e13873c100" width="200" />
</td>
</tr>
</table>

