### PR TITLE
Fix species z-index

### DIFF
--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="multi-container" ref="multiContainer">
-    <div style="position: absolute; z-index: 10" v-if="!disableUI">
+    <div style="position: absolute; z-index: 100" v-if="!disableUI">
       <div class="species-display-text">Species</div>
       <el-popover
         content="Select a species"


### PR DESCRIPTION
After [the pathway container's z-index is fixed](https://github.com/ABI-Software/flatmapvuer/pull/203), the species in the selection are covered by the pathway container because z-index of the species selector is lower than the pathway container. 

This PR is to fix the issue.

<img src="https://github.com/user-attachments/assets/f8273024-e8b7-4ebc-b775-5ee1058ebcc7" width="350" />
