### PR TITLE
Annotation sidebar fix

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -971,10 +971,8 @@ export default {
           if (this.annotationSidebar) this.$emit("annotation-close")
           this.closeTooltip()
           this.annotationEntry = {}
-        } else {
-          // Update 'existDrawnFeatures' when created or updated event
-          this.addAnnotationFeature()
         }
+        this.addAnnotationFeature()
       }
     },
     /**
@@ -2913,9 +2911,7 @@ export default {
             this.showAnnotator(true)
             this.userInformation = userData
             this.setFeatureAnnotated()
-            if (this.existDrawnFeatures.length === 0) {
-              this.addAnnotationFeature()
-            }
+            this.addAnnotationFeature()
           }
           this.loading = false
         })

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -761,6 +761,15 @@ export default {
   methods: {
     /**
      * @public
+     * Function to manually send aborted signal when annotation tooltip popup or sidebar tab closed.
+     */
+    manualAbortedOnClose: function () {
+      if (this.annotationSidebar) this.$emit("annotation-close")
+      this.closeTooltip()
+      this.annotationEventCallback({}, { type: 'aborted' })
+    },
+    /**
+     * @public
      * Function to initialise drawing.
      */
     initialiseDrawing: function () {
@@ -833,17 +842,7 @@ export default {
      * @arg {String} `name`
      */
     toolbarEvent: function (type, name) {
-      if (this.annotationSidebar) {
-        this.$emit("annotation-close")
-        if (!this.featureAnnotationSubmitted) {
-          this.rollbackAnnotationEvent()
-        }
-      }
-      this.closeTooltip()
-      // rollback feature if not submitted
-      if (Object.keys(this.annotationEntry).length > 0 && !this.featureAnnotationSubmitted) {
-        this.rollbackAnnotationEvent()
-      }
+      this.manualAbortedOnClose()
       this.doubleClickedFeature = false
       this.connectionEntry = {}
       if (type === 'mode') {
@@ -1065,6 +1064,7 @@ export default {
     setDrawnType: function (flag) {
       this.drawnType = flag
       if (this.mapImp) {
+        this.manualAbortedOnClose()
         this.addAnnotationFeature()
         this.initialiseDrawing()
       }
@@ -1077,6 +1077,7 @@ export default {
     setAnnotatedType: function (flag) {
       this.annotatedType = flag
       if (this.mapImp) {
+        this.manualAbortedOnClose()
         this.addAnnotationFeature()
       }
     },
@@ -1722,12 +1723,7 @@ export default {
       if (modeName) {
         this.viewingMode = modeName
       }
-      if (this.annotationSidebar) this.$emit("annotation-close")
-      this.closeTooltip()
-      // rollback feature if not submitted
-      if (Object.keys(this.annotationEntry).length > 0 && !this.featureAnnotationSubmitted) {
-        this.rollbackAnnotationEvent()
-      }
+      this.manualAbortedOnClose()
     },
     /**
      * @public

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -766,7 +766,6 @@ export default {
     manualAbortedOnClose: function () {
       if (this.annotationSidebar) this.$emit("annotation-close")
       this.closeTooltip()
-      this.annotationEntry = {}
       this.annotationEventCallback({}, { type: 'aborted' })
     },
     /**
@@ -1581,6 +1580,7 @@ export default {
         // Rollback drawing when no new annotation submitted
         if (!this.featureAnnotationSubmitted) this.rollbackAnnotationEvent()
         else this.featureAnnotationSubmitted = false
+        this.annotationEntry = {}
       } else if (data.type === 'modeChanged') {
         if (data.feature.mode === 'direct_select') this.doubleClickedFeature = true
         if (this.annotationSidebar && data.feature.mode === 'simple_select') {

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -766,6 +766,7 @@ export default {
     manualAbortedOnClose: function () {
       if (this.annotationSidebar) this.$emit("annotation-close")
       this.closeTooltip()
+      this.annotationEntry = {}
       this.annotationEventCallback({}, { type: 'aborted' })
     },
     /**

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1616,6 +1616,8 @@ export default {
         if (data.type === 'created') this.drawnCreatedEvent = payload
         else this.checkAndCreatePopups(payload)
       }
+      if (data.type === 'deleted') this.previousDeletedEvent = data
+      else this.previousDeletedEvent = {}
     },
     /**
      * @public
@@ -1737,6 +1739,13 @@ export default {
       // Call flatmap database to get the connection data
       if (this.viewingMode === 'Annotation') {
         if (data.feature) {
+          if (this.annotationSidebar && this.previousDeletedEvent.type === 'deleted') {
+            this.annotationEntry = {
+              ...this.previousDeletedEvent,
+              resourceId: this.serverURL
+            }
+            this.annotationEventCallback({}, { type: 'aborted' })
+          }
           this.annotationEntry = {
             ...data.feature,
             resourceId: this.serverURL,
@@ -2838,6 +2847,7 @@ export default {
       activeDrawTool: undefined,
       featureAnnotationSubmitted: false,
       drawnCreatedEvent: {},
+      previousDeletedEvent: {},
       connectionEntry: {},
       existDrawnFeatures: [], // Store all exist drawn features
       doubleClickedFeature: false,

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1583,6 +1583,9 @@ export default {
         else this.featureAnnotationSubmitted = false
       } else if (data.type === 'modeChanged') {
         if (data.feature.mode === 'direct_select') this.doubleClickedFeature = true
+        if (this.annotationSidebar && data.feature.mode === 'simple_select') {
+          this.annotationEventCallback({}, { type: 'aborted' })
+        }
       } else if (data.type === 'selectionChanged') {
         this.selectedDrawnFeature = data.feature.features.length === 0 ?
           undefined : data.feature.features[0]


### PR DESCRIPTION
Fixed three possible issues below:

- Clicking on the different drawn features, the annotation sidebar tab may not appear. It will somehow affect some other annotator functionality.
- Previously selected drawn features will disappear when clicking on the different drawn features without closing the sidebar tab.
- Filtering drawn features immediately after creating/editing a feature (annotation UI is opened).

All issues are caused by the `aborted` callback, which no longer exists when switched to show content on the sidebar. Fixed by manually adding `aborted` callbacks.