### PR TITLE
Improve UX when invalid drawing happens

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2935,12 +2935,23 @@ export default {
         const events = ['keydown', 'click', 'dblclick']
         const canvas = this.$el.querySelector('.maplibregl-canvas');
         const invalidDrawHandler = () => {
-          if (!this.isValidDrawnCreated) this.activeDrawTool = undefined
+          if (!this.isValidDrawnCreated) {
+            this.activeDrawTool = undefined
+            clickPoints = {}
+          }
         }
         events.forEach((e) => {
           canvas.addEventListener(e, (event) => {
-            if (e === 'keydown' && event.key !== 'Escape') return;
-            if (e === 'click') {
+            if (e === 'keydown') {
+              if (event.key === 'Enter') {
+                if (
+                  (tool === 'LineString' && Object.keys(clickPoints).length >= 2) ||
+                  (tool === 'Polygon' && Object.keys(clickPoints).length >= 3)
+                ) return;
+              } else {
+                if (event.key !== 'Escape') return;
+              }
+            } else if (e === 'click') {
               if (!(event.x in clickPoints)) clickPoints[event.x] = []
               if (!clickPoints[event.x].includes(event.y)) {
                 clickPoints[event.x].push(event.y)
@@ -2948,8 +2959,8 @@ export default {
               }
             }
             invalidDrawHandler()
-            canvas.removeEventListener(e, invalidDrawHandler)
           })
+          canvas.removeEventListener(e, invalidDrawHandler)
         })
       }
     }

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2931,13 +2931,13 @@ export default {
     },
     activeDrawTool: function (tool) {
       if (tool) {
-        let clickPoints = {}
+        let coordinates = {}
         const events = ['keydown', 'click', 'dblclick']
         const canvas = this.$el.querySelector('.maplibregl-canvas');
         const invalidDrawHandler = () => {
           if (!this.isValidDrawnCreated) {
             this.activeDrawTool = undefined
-            clickPoints = {}
+            coordinates = {}
           }
         }
         events.forEach((e) => {
@@ -2945,16 +2945,16 @@ export default {
             if (e === 'keydown') {
               if (event.key === 'Enter') {
                 if (
-                  (tool === 'LineString' && Object.keys(clickPoints).length >= 2) ||
-                  (tool === 'Polygon' && Object.keys(clickPoints).length >= 3)
+                  (tool === 'LineString' && Object.keys(coordinates).length >= 2) ||
+                  (tool === 'Polygon' && Object.keys(coordinates).length >= 3)
                 ) return;
               } else {
                 if (event.key !== 'Escape') return;
               }
             } else if (e === 'click') {
-              if (!(event.x in clickPoints)) clickPoints[event.x] = []
-              if (!clickPoints[event.x].includes(event.y)) {
-                clickPoints[event.x].push(event.y)
+              if (!(event.x in coordinates)) coordinates[event.x] = []
+              if (!coordinates[event.x].includes(event.y)) {
+                coordinates[event.x].push(event.y)
                 return;
               }
             }

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2928,6 +2928,30 @@ export default {
       if (isUIDisabled) {
         this.closeTooltip()
       }
+    },
+    activeDrawTool: function (tool) {
+      if (tool) {
+        let clickPoints = {}
+        const events = ['keydown', 'click', 'dblclick']
+        const canvas = this.$el.querySelector('.maplibregl-canvas');
+        const invalidDrawHandler = () => {
+          if (!this.isValidDrawnCreated) this.activeDrawTool = undefined
+        }
+        events.forEach((e) => {
+          canvas.addEventListener(e, (event) => {
+            if (e === 'keydown' && event.key !== 'Escape') return;
+            if (e === 'click') {
+              if (!(event.x in clickPoints)) clickPoints[event.x] = []
+              if (!clickPoints[event.x].includes(event.y)) {
+                clickPoints[event.x].push(event.y)
+                return;
+              }
+            }
+            invalidDrawHandler()
+            canvas.removeEventListener(e, invalidDrawHandler)
+          })
+        })
+      }
     }
   },
   mounted: function () {


### PR DESCRIPTION
The following cases will cause some UX issues:

- Pressing `ESC` will cancel a drawing, but the tool button will still be selected.
- Drawing a point (clicking on the same position twice) when the line tool is selected. The drawing will be cancelled, but the tool button will still be selected.
- Drawing a point/line when the polygon tool is selected. The drawing will be cancelled, but the tool button will still be selected.
- Pressing `Enter/Return` when a drawing is not completed. The drawing will be cancelled, but the tool button will still be selected.

The reason is that we switched from using the built-in toolbar to using direct API calls. Some of the keyboard and mouse support no longer exist.