### PR TITLE
Disable zoom on connectivity highlight

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1835,7 +1835,7 @@ export default {
         }
 
         // highlight all available features
-        this.mapImp.zoomToFeatures(featuresToHighlight, { noZoomIn: true });
+        this.mapImp.selectFeatures(featuresToHighlight);
       }
     },
     emitConnectivityGraphError: function (errorData) {


### PR DESCRIPTION
This prevents map zooming and moving when the mouse is over on sidebar connectivity.