### PR TITLE
Fix hover over the map after connectivity tooltip shown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmap-viewer": "3.2.11",
+        "@abi-software/flatmap-viewer": "3.2.12",
         "@abi-software/map-utilities": "^1.3.1",
         "@abi-software/sparc-annotation": "0.3.2",
         "@abi-software/svg-sprite": "^1.0.1",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@abi-software/flatmap-viewer": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-3.2.11.tgz",
-      "integrity": "sha512-aABuG7fYad5/5gqwHf2UDXTo6n+4SHGILaLkUjv65efuZtyPPleUVpZt9QO0rWV6VpQX/VMHYOG9v2AuzSKzVQ==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-3.2.12.tgz",
+      "integrity": "sha512-IwbePQMIZkEK/NN+cEQlI/Viol7WkQ4H4t/bA3NK9Ok1cI5OqS1vLrOHdPG+mSNj5d4vLoEFFC9x/IFhPTDngA==",
       "dependencies": {
         "@deck.gl/core": "^9.0.17",
         "@deck.gl/geo-layers": "^9.0.18",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "./src/*": "./src/*"
   },
   "dependencies": {
-    "@abi-software/flatmap-viewer": "3.2.11",
+    "@abi-software/flatmap-viewer": "3.2.12",
     "@abi-software/map-utilities": "^1.3.1",
     "@abi-software/sparc-annotation": "0.3.2",
     "@abi-software/svg-sprite": "^1.0.1",

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -3411,6 +3411,12 @@ export default {
       border-style: solid;
       flex-shrink: 0;
     }
+
+    hr {
+      margin: 0.5rem 0;
+      border: 0;
+      border-top: 1px solid var(--el-border-color);
+    }
   }
   .maplibregl-popup-tip {
     display: none;

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -644,7 +644,7 @@ const centroid = (geometry) => {
   } else {
     coordinates = geometry.coordinates
   }
-  if (coordinates) {    
+  if (coordinates) {
     if (!(geometry.type === 'Point')) {
       coordinates.map((coor) => {
         featureGeometry.lng += parseFloat(coor[0])
@@ -1703,6 +1703,15 @@ export default {
      * Function to remove active tooltips on map.
      */
     removeActiveTooltips: function () {
+      // Remove active tooltip/popup on map
+      if (this.mapImp) {
+        const currentPopup = this.mapImp._userInteractions?._currentPopup;
+        if (currentPopup) {
+          currentPopup.remove();
+        }
+      }
+
+      // Fallback: remove any existing toolitp on DOM
       const tooltips = this.$el.querySelectorAll('.flatmap-tooltip-popup');
       tooltips.forEach((tooltip) => tooltip.remove());
     },

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1705,10 +1705,7 @@ export default {
     removeActiveTooltips: function () {
       // Remove active tooltip/popup on map
       if (this.mapImp) {
-        const currentPopup = this.mapImp._userInteractions?._currentPopup;
-        if (currentPopup) {
-          currentPopup.remove();
-        }
+        this.mapImp.removePopup();
       }
 
       // Fallback: remove any existing toolitp on DOM


### PR DESCRIPTION
The new `removePopup` method will be used after the new version of `flatmap-viewer` is released (https://github.com/AnatomicMaps/flatmap-viewer/pull/48).