### PR TITLE
Update flatmap-viewer 3.2.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abi-software/flatmap-viewer": "3.2.12",
+        "@abi-software/flatmap-viewer": "3.2.13",
         "@abi-software/map-utilities": "^1.3.2",
         "@abi-software/sparc-annotation": "0.3.2",
         "@abi-software/svg-sprite": "^1.0.1",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@abi-software/flatmap-viewer": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-3.2.12.tgz",
-      "integrity": "sha512-IwbePQMIZkEK/NN+cEQlI/Viol7WkQ4H4t/bA3NK9Ok1cI5OqS1vLrOHdPG+mSNj5d4vLoEFFC9x/IFhPTDngA==",
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/@abi-software/flatmap-viewer/-/flatmap-viewer-3.2.13.tgz",
+      "integrity": "sha512-sYkdSTW5D9YMGR/Dp+lfXYkuXI58kytSU0UPQ97mF9WeT7IXEx6zfOPmNlUCrjz3G29Am6tM567BrllKrTmVcQ==",
       "dependencies": {
         "@deck.gl/core": "^9.0.17",
         "@deck.gl/geo-layers": "^9.0.18",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "./src/*": "./src/*"
   },
   "dependencies": {
-    "@abi-software/flatmap-viewer": "3.2.12",
+    "@abi-software/flatmap-viewer": "3.2.13",
     "@abi-software/map-utilities": "^1.3.2",
     "@abi-software/sparc-annotation": "0.3.2",
     "@abi-software/svg-sprite": "^1.0.1",


### PR DESCRIPTION
`flatmap-viewer` version update to fix centreline multiple clicks issue.