### PR TITLE
Fix missing features alert for display search

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2688,6 +2688,7 @@ export default {
                   provenanceTaxonomy: feature.taxons,
                 }
                 if (this.viewingMode === "Exploration" || this.viewingMode === "Annotation") {
+                  this.featuresAlert = feature.alert
                   this.checkAndCreatePopups(data)
                 } else if (this.viewingMode === 'Neuron Connection') {
                   setTimeout(() => {


### PR DESCRIPTION
"Neuron type mmset4 5" has an alert, but it is not showing if the connectivity info is shown from the display search. It works for clicking on neuron population.

### Steps to replicate the issue
Search "Neuron type mmset4 5" or "inferior vagus X ganglion to NTS via vagus" in display search and click the dropdown result. 
Click "Neuron type mmset4 5" or "inferior vagus X ganglion to NTS via vagus" on the Map.