### PR TITLE
Remove duplicate origins in connectivity

### DIFF
--- a/src/services/flatmapQueries.js
+++ b/src/services/flatmapQueries.js
@@ -445,6 +445,7 @@ let FlatmapQueries = function () {
         if (connectivity.dendrites && connectivity.dendrites.length > 0) {
           dendrites.push(...connectivity.dendrites)
         }
+        dendrites = removeDuplicates(dendrites)
         somas = connectivity.somas
       }
 


### PR DESCRIPTION
The data, `UBERON:0001989`,  is in both `dendrites` and `somas`.

<img src="https://github.com/user-attachments/assets/63d3a83d-fb6f-44b8-ba02-9fb658502a57" width="300">
