### PR TITLE
Prevent creating popup for empty background area click

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -277,6 +277,7 @@ export default {
         },
         Vagus: {
           taxo: 'UBERON:0001759',
+          uuid: "0ea568ec-538d-52f3-a8e7-0437d844e1cf",
         },
         Sample: { taxo: 'NCBITaxon:1', displayWarning: true },
         'Functional Connectivity': {

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2340,6 +2340,7 @@ export default {
       // Provenance popup will be shown on map
       // Tooltip will be shown for Annotation view
       if (
+        featureId &&
         !this.disableUI &&
         (
           (this.viewingMode === 'Annotation' && !this.annotationSidebar) ||

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1935,7 +1935,7 @@ export default {
     },
     changeConnectivitySource: async function (payload) {
       const { entry, connectivitySource } = payload;
-      if (entry.mapId === this.mapImp.id) {        
+      if (entry.mapId === this.mapImp.id) {
         await this.flatmapQueries.queryForConnectivityNew(this.mapImp, entry.featureId[0], connectivitySource);
         this.tooltipEntry = this.tooltipEntry.map((tooltip) => {
           if (tooltip.featureId[0] === entry.featureId[0]) {
@@ -2315,7 +2315,9 @@ export default {
         options.annotationFeatureGeometry = geometry
       } else {
         const entry = Array.isArray(feature) ? feature[0] : feature
-        featureId = this.mapImp.modelFeatureIds(entry)[0]
+        if (entry) {
+          featureId = this.mapImp.modelFeatureIds(entry)[0]
+        }
         if (!this.activeDrawTool) {
           options.positionAtLastClick = true
         }


### PR DESCRIPTION
On the Vagus flatmap, there is a background area without any model ID. Clicking those areas throws an error. This pull request is to prevent creating a popup if there is no model ID.