### PR TITLE
Fix tooltip and remove duplicate codes

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -3477,7 +3477,8 @@ export default {
   max-width: 330px !important;
 }
 
-:deep(.flatmap-tooltip-popup) {
+:deep(.flatmap-tooltip-popup),
+:deep(.custom-popup) {
   &.maplibregl-popup-anchor-bottom {
     .maplibregl-popup-content {
       margin-bottom: 12px;
@@ -4002,77 +4003,14 @@ export default {
 }
 
 :deep(.custom-popup) {
-  .maplibregl-popup-tip {
-    display: none;
-  }
   .maplibregl-popup-content {
-    border-radius: 4px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-    pointer-events: none;
-    display: none;
-    background: #fff;
     font-family: 'Asap', sans-serif;
     font-size: 12pt;
     color: $app-primary-color;
-    border: 1px solid $app-primary-color;
-    padding-left: 6px;
     padding-right: 6px;
     padding-top: 6px;
-    padding-bottom: 6px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    &::after,
-    &::before {
-      content: '';
-      display: block;
-      position: absolute;
-      width: 0;
-      height: 0;
-      border-style: solid;
-      flex-shrink: 0;
-    }
     .maplibregl-popup-close-button {
       display: none;
-    }
-  }
-  &.maplibregl-popup-anchor-bottom {
-    .maplibregl-popup-content {
-      margin-bottom: 12px;
-      &::after,
-      &::before {
-        top: 100%;
-        border-width: 12px;
-      }
-      /* this border color controlls the color of the triangle (what looks like the fill of the triangle) */
-      &::after {
-        margin-top: -1px;
-        border-color: rgb(255, 255, 255) transparent transparent transparent;
-      }
-      /* this border color controlls the outside, thin border */
-      &::before {
-        margin: 0 auto;
-        border-color: $app-primary-color transparent transparent transparent;
-      }
-    }
-  }
-  &.maplibregl-popup-anchor-top {
-    .maplibregl-popup-content {
-      margin-top: 18px;
-      &::after,
-      &::before {
-        top: calc(-100% + 6px);
-        border-width: 12px;
-      }
-      /* this border color controlls the color of the triangle (what looks like the fill of the triangle) */
-      &::after {
-        margin-top: 1px;
-        border-color: transparent transparent rgb(255, 255, 255) transparent;
-      }
-      &::before {
-        margin: 0 auto;
-        border-color: transparent transparent $app-primary-color transparent;
-      }
     }
   }
 }


### PR DESCRIPTION
Clicking on an item in the connectivity explorer opens a tooltip on the map. The original tooltip bottom position works fine, but the arrow in other positions does not show correctly. 
This PR fixes that issue.

**Tooltip bottom**
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/3f2c7fb7-6051-45b6-8712-83fe641794bf" width="400" />
</td>
</tr>
</table>


**Tooltip top** 
<table>
<tr><td>before</td><td>after</td></tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/9a2cdd2f-e801-4f59-bcf0-408ed7c94b18" width="400" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/03da011f-e1fa-4d41-956d-09a2c782f2bc" width="400" />
</td>
</tr>
</table>


**Tooltip left**
<table>
<tr><td>before</td><td>after</td></tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/c11ecee7-0f03-4705-8073-a5163dee16fb" width="400" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/6edb439a-89d9-407a-af2d-56fb2e51ed76" width="400" />
</td>
</tr>
</table>

**Tooltip right**
<table>
<tr><td>before</td><td>after</td></tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/f216d200-492f-4f97-a8e2-faed13b43dbb" width="400" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/4baccddb-6d20-4b03-aaf5-7cfd856a3f13" width="400" />
</td>
</tr>
</table>

