### PR TITLE
Emit emitOfflineAnnotationUpdate for Annotation Mode in Global Settings Toolbar 

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1059,6 +1059,12 @@ export default {
       }
     },
     /**
+     * Function to emit offline annotation enabled status
+     */
+    emitOfflineAnnotationUpdate: function () {
+      this.$emit('update-offline-annotation-enabled', this.offlineAnnotationEnabled);
+    },
+    /**
      * @public
      * Function to switch from 2D to 3D
      * @arg {Boolean} `flag`
@@ -3233,6 +3239,7 @@ export default {
             this.authorisedUser = undefined
             this.offlineAnnotationEnabled = true
           }
+          this.emitOfflineAnnotationUpdate();
           this.setFeatureAnnotated()
           this.addAnnotationFeature()
           this.loading = false

--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -65,6 +65,7 @@
       :annotationSidebar="annotationSidebar"
       @annotation-open="onAnnotationOpen"
       @annotation-close="onAnnotationClose"
+      @update-offline-annotation-enabled="updateOfflineAnnotationEnabled"
       :connectivityInfoSidebar="connectivityInfoSidebar"
       @connectivity-info-open="onConnectivityInfoOpen"
       @connectivity-info-close="onConnectivityInfoClose"
@@ -290,6 +291,9 @@ export default {
     },
     onAnnotationOpen: function (payload) {
       this.$emit('annotation-open', payload);
+    },
+    updateOfflineAnnotationEnabled: function (payload) {
+      this.$emit('update-offline-annotation-enabled', payload);
     },
     onConnectivityInfoClose: function () {
       this.$emit('connectivity-info-close');


### PR DESCRIPTION
The event name `update-offline-annotation-enabled` with `offlineAnnotationEnabled` data is emitted to use in `mapintegratedvuer`'s global settings toolbar. 

The same method as in https://github.com/ABI-Software/scaffoldvuer/pull/164. 