### PR TITLE
Remove pathways query since it is available on mapImp.pathways

### DIFF
--- a/src/services/flatmapQueries.js
+++ b/src/services/flatmapQueries.js
@@ -344,20 +344,6 @@ let FlatmapQueries = function () {
     }
   }
 
-  this.queryMapPaths =  async function (mapuuid) {
-    const url = this.flatmapAPI + `flatmap/${mapuuid}/pathways`;
-
-    try {
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw new Error(`Response status: ${response.status}`);
-      }
-      return await response.json();
-    } catch (error) {
-      throw new Error(error);
-    }
-  }
-
   this.queryForConnectivity = function (mapImp, keastIds, signal, processConnectivity=true) {
     const data = { sql: this.buildConnectivitySqlStatement(keastIds) }
     const headers = {


### PR DESCRIPTION
The data is available as `mapImp.pathways`, and this pathways query is not necessary anymore.
