### PR TITLE
Update valid pathways filter options

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -2765,9 +2765,7 @@ export default {
           if (key === "kind") {
             main.label = "Pathways"
             for (const facet of value) {
-              const pathway = this.pathways.find(path => {
-                return !['other', 'centreline'].includes(path.type) && path.type === facet
-              })
+              const pathway = this.pathways.find(path => path.type === facet)
               if (pathway) {
                 main.children.push({
                   key: `${main.key}.${facet}`,
@@ -2833,7 +2831,9 @@ export default {
       this.mapImp.setBackgroundOpacity(1)
       this.backgroundChangeCallback(this.currentBackground)
       this.pathways = this.mapImp.pathTypes()
-      this.pathways = this.pathways.filter(path => !['other', 'centreline'].includes(path.type))
+      this.pathways = this.pathways.filter(path => {
+        return path.enabled && path.type !== 'other'
+      })
       //Disable layers for now
       //this.layers = this.mapImp.getLayers();
       this.processSystems(this.mapImp.getSystems())


### PR DESCRIPTION
The FC map has two `blood vessel` options, which do not work the same as other neuron connectivity. It will cause the explorer facet search issue. Remove from both the left-hand side and the explorer filter option for now.

<img width="1512" alt="Screenshot 2025-07-01 at 4 33 43 PM" src="https://github.com/user-attachments/assets/5f8a1f33-df4b-4ae6-a106-cd2f55782e82" />

path types in viewer:
<img width="766" alt="Screenshot 2025-07-01 at 4 54 49 PM" src="https://github.com/user-attachments/assets/9b56d19e-786b-43cc-b9e0-6e8f761221d4" />
