### PR TITLE
Update flatmap-viewer 4.3.5

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -647,7 +647,7 @@ import {
 import { capitalise } from './utilities.js'
 import yellowstar from '../icons/yellowstar'
 import ResizeSensor from 'css-element-queries/src/ResizeSensor'
-import * as flatmap from 'https://cdn.jsdelivr.net/npm/@abi-software/flatmap-viewer@4.3.0/+esm'
+import * as flatmap from 'https://cdn.jsdelivr.net/npm/@abi-software/flatmap-viewer@4.3.5/+esm'
 import { AnnotationService } from '@abi-software/sparc-annotation'
 import { mapState } from 'pinia'
 import { useMainStore } from '@/store/index'

--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -104,7 +104,7 @@
 import { markRaw } from 'vue'
 import EventBus from './EventBus'
 import FlatmapVuer from './FlatmapVuer.vue'
-import * as flatmap from 'https://cdn.jsdelivr.net/npm/@abi-software/flatmap-viewer@4.3.0/+esm'
+import * as flatmap from 'https://cdn.jsdelivr.net/npm/@abi-software/flatmap-viewer@4.3.5/+esm'
 import {
   ElCol as Col,
   ElOption as Option,


### PR DESCRIPTION
Updating flatmap-viewer 4.3.5 will change `marker-terms` to `daataset-terms`.
The following update is needed in mapintegratedvuer.
https://github.com/ABI-Software/mapintegratedvuer/commit/a2702877fd1cb8c8fa40ab9d36c9099b65b6e539
It is added in https://github.com/ABI-Software/mapintegratedvuer/compare/main...map-viewer-1.13.x.
