### PR TITLE
Centralise flatmap-viewer import

### DIFF
--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -647,7 +647,7 @@ import {
 import { capitalise } from './utilities.js'
 import yellowstar from '../icons/yellowstar'
 import ResizeSensor from 'css-element-queries/src/ResizeSensor'
-import * as flatmap from 'https://cdn.jsdelivr.net/npm/@abi-software/flatmap-viewer@4.3.5/+esm'
+import flatmap from '../services/flatmapLoader.js'
 import { AnnotationService } from '@abi-software/sparc-annotation'
 import { mapState } from 'pinia'
 import { useMainStore } from '@/store/index'

--- a/src/components/MultiFlatmapVuer.vue
+++ b/src/components/MultiFlatmapVuer.vue
@@ -104,7 +104,7 @@
 import { markRaw } from 'vue'
 import EventBus from './EventBus'
 import FlatmapVuer from './FlatmapVuer.vue'
-import * as flatmap from 'https://cdn.jsdelivr.net/npm/@abi-software/flatmap-viewer@4.3.5/+esm'
+import flatmap from '../services/flatmapLoader.js'
 import {
   ElCol as Col,
   ElOption as Option,

--- a/src/services/flatmapLoader.js
+++ b/src/services/flatmapLoader.js
@@ -1,0 +1,6 @@
+/**
+ * a single source for the flatmap-viewer library import
+ */
+import * as flatmap from 'https://cdn.jsdelivr.net/npm/@abi-software/flatmap-viewer@4.3.5/+esm';
+
+export default flatmap;


### PR DESCRIPTION
Using a single source for `flatmap-viewer` import for easier maintenance and to avoid misconfiguration in updating `flatmap-viewer` version. 